### PR TITLE
Add location dimension

### DIFF
--- a/Ping_Gathering/create_inserter_user.py
+++ b/Ping_Gathering/create_inserter_user.py
@@ -5,3 +5,4 @@ inserter_user = f"{get_user_base()}.ping_inserter"
 with get_connection() as connection:
     execute_sql(connection, f'''CREATE USER "{inserter_user}" IDENTIFIED BY '{inserter_password}';''')
     execute_sql(connection, f'''GRANT INSERT ON TABLE ping_data TO "{inserter_user}"''')
+    execute_sql(connection, f'''GRANT INSERT, SELECT ON TABLE location_dimension TO "{inserter_user}"''')

--- a/Ping_Gathering/create_tables.py
+++ b/Ping_Gathering/create_tables.py
@@ -9,5 +9,17 @@ with get_connection() as connection:
             location text,
             ping_type smallint,
             ip_addr text,
+            location_key integer,
         );
+    """)
+
+    execute_sql(connection, """
+        CREATE TABLE IF NOT EXISTS location_dimension(
+            location_key serial,
+            ip_address text,
+            country text,
+            country_code text,
+            latitude decimal(11, 7),
+            longitude decimal(11, 7)
+        )
     """)

--- a/Ping_Gathering/ping_saver.py
+++ b/Ping_Gathering/ping_saver.py
@@ -15,7 +15,7 @@ def getLocation(ipAddr):
     json = response.json()
     return json
 
-def get_location_key(ip_address):
+def get_location_key(connection, ip_address):
     location = getLocation(ip_address)
     location_tuple = (
         ip_address,
@@ -68,7 +68,7 @@ def store_head_requests(connection):
     while True:
         try:
             my_ip = requests.get("http://ifconfig.me").text
-            location_key = get_location_key(my_ip)
+            location_key = get_location_key(connection, my_ip)
             break
         except Exception as e:
             logging.exception("Failed to determine location! Trying again in 60s...")
@@ -122,12 +122,12 @@ with open("servers.json", "w") as f:
     f.write(json.dumps({"valid_servers": valid_servers, "invalid_servers": invalid_servers}))
 exit(0)
 '''
-
-prev_end_time = time.time()
-with get_connection(user="ping_inserter", password="665404ebeb06") as connection:
-    while True:
-        store_head_requests(connection)
-        end_time = time.time()
-        elapsed = end_time - prev_end_time
-        prev_end_time = end_time
-        time.sleep(max(0, 60 - elapsed))
+if __name__ == "__main__":
+    prev_end_time = time.time()
+    with get_connection(user="ping_inserter", password="665404ebeb06") as connection:
+        while True:
+            store_head_requests(connection)
+            end_time = time.time()
+            elapsed = end_time - prev_end_time
+            prev_end_time = end_time
+            time.sleep(max(0, 60 - elapsed))

--- a/Ping_Gathering/ping_saver.py
+++ b/Ping_Gathering/ping_saver.py
@@ -1,5 +1,6 @@
 import time
 import datetime
+import logging
 import requests
 import json
 
@@ -8,8 +9,70 @@ from connector import get_connection, execute_sql
 with open("Ping_Gathering/servers.json") as f:
     hostnames = json.load(f)["valid_servers"]
 
+def getLocation(ipAddr):
+    endPoint = 'http://ip-api.com/json/%s?fields=country,countryCode,lat,lon'%(ipAddr)
+    response = requests.get(endPoint)
+    json = response.json()
+    return json
+
+def get_location_key(ip_address):
+    location = getLocation(ip_address)
+    location_tuple = (
+        ip_address,
+        location["country"],
+        location["countryCode"],
+        location["lat"],
+        location["lon"],
+    )
+    execute_sql(
+        connection,
+        """
+        INSERT INTO location_dimension(
+            ip_address, country, country_code, latitude, longitude
+        )
+        WITH record_to_insert AS (
+        SELECT  %s as ip_address,
+                %s AS country,
+                %s AS country_code,
+                CAST(%s AS decimal(11,7)) AS latitude,
+                CAST(%s AS decimal(11,7)) AS longitude
+        ), existing_location AS (
+            SELECT location_key
+            FROM location_dimension
+            INNER JOIN record_to_insert
+            USING (ip_address, country, country_code, latitude, longitude)
+        )
+        SELECT ip_address, country, country_code, latitude, longitude
+        FROM record_to_insert
+        LEFT JOIN existing_location ON TRUE
+        WHERE existing_location.location_key IS NULL;
+        """,
+        location_tuple,
+    )
+    return execute_sql(
+        connection,
+        """
+        SELECT location_key
+        FROM location_dimension
+        WHERE ip_address = %s
+            AND country = %s
+            AND country_code = %s
+            AND latitude = CAST(%s AS decimal(11,7))
+            AND longitude = CAST(%s AS decimal(11,7))
+        """,
+        location_tuple,
+    )[0][0]
+
+
 def store_head_requests(connection):
-    my_ip = requests.get("http://ifconfig.me").text
+    while True:
+        try:
+            my_ip = requests.get("http://ifconfig.me").text
+            location_key = get_location_key(my_ip)
+            break
+        except Exception as e:
+            logging.exception("Failed to determine location! Trying again in 60s...")
+            time.sleep(60)
     latencies = []
     times = []
 
@@ -25,7 +88,7 @@ def store_head_requests(connection):
     records = []
     for hostname, latency, times in zip(hostnames, latencies, times):
         records.append(
-            (datetime.datetime.now(), int(latency*1000000), hostname, "us-east-2", 1, my_ip),
+            (datetime.datetime.now(), int(latency*1000000), hostname, 1, location_key),
         )
 
     with connection.cursor() as cursor:
@@ -34,11 +97,10 @@ def store_head_requests(connection):
                 ping_time,
                 ping_latency_ns,
                 server_hostname,
-                location,
                 ping_type,
-                ip_addr
+                location_key
             ) VALUES (
-                %s, %s, %s, %s, %s, %s
+                %s, %s, %s, %s, %s
             );
         """, records
         )


### PR DESCRIPTION
The plan is to delete `ip_addr` and `location` from ping_data shortly. You can now get ip address (or lat/longitude) with, for example:
```
SELECT ping_time, ping_latency_ns, ip_address, latitude, longitude
FROM ping_data
INNER JOIN location_dimension
USING (location_key)
LIMIT 10
```

NOTE: I experimented with making latitude and longitude a "decimal" data format, in an attempt to deal w/ float imprecision. I believe Python handles that exactly as it would any other numeric data type, but if that causes any headaches, let me know, I can change it. (Or `float(latitude)` could be done Python-side)

Also I'm happy to take any naming comments (location_dimension vs just locations, ip_address vs ip_addr, etc.)