### PR TITLE
Add ICMP pings, run pings in parallel

### DIFF
--- a/Ping_Gathering/ping_saver.py
+++ b/Ping_Gathering/ping_saver.py
@@ -1,8 +1,18 @@
-import time
+import concurrent.futures
 import datetime
-import logging
-import requests
 import json
+import logging
+import platform
+import re
+import requests
+import subprocess
+import time
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] %(funcName)s(): %(message)s'
+)
+
 
 from connector import get_connection, execute_sql
 
@@ -64,7 +74,63 @@ def get_location_key(connection, ip_address):
     )[0][0]
 
 
-def store_head_requests(connection):
+def measure_head_request(hostname):
+    start_time = datetime.datetime.now()
+    try:
+        latency = requests.head(f"http://{hostname}").elapsed.total_seconds()
+        latency_ns = round(latency * 1000000)
+    except Exception:
+        logging.exception("Failed to run HTTP HEAD request!")
+        latency_ns = None
+    return start_time, latency_ns
+
+def measure_ping_request(hostname):
+    param = "-n" if "windows" in platform.system().lower() else "-c"
+    start_time = datetime.datetime.now()
+    result = None
+    try:
+        result = str(subprocess.check_output(["ping", param, "1", hostname]))
+    except Exception:
+        logging.exception("Failed to run ICMP ping!")
+        latency_ns = None
+    else: # if no exception
+        try:
+            m = re.search("time\s*=\s*([\d\.]+)\s*ms", result)
+            ping_ms_string = m.group(1)
+        except Exception:
+            logging.exception(f"Failed to parse {result}!")
+            latency_ns = None
+        else: # if no exception
+            try:
+                latency_ns = round(float(ping_ms_string)*1000)
+            except Exception:
+                logging.exception(f"Failed to parse ping time of {ping_ms_string}")
+                latency_ns = None
+
+    return start_time, latency_ns
+
+
+def measure_latencies(measure_function, hostnames, extra_rows = []):
+    futures = []
+    start_times = []
+    latencies = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+        for hostname in hostnames:
+            futures.append(executor.submit(measure_function, hostname))
+        for future in futures:
+            start_time, latency = future.result()
+            start_times.append(start_time)
+            latencies.append(latency)
+
+    records = []
+    for hostname, latency, start_time in zip(hostnames, latencies, start_times):
+        records.append(
+            tuple([start_time, latency, hostname] + extra_rows)
+        )
+    logging.info(f"Finished running {measure_function.__name__} {len(hostnames)} times")
+    return records
+
+def store_ping_and_head_latencies(connection):
     while True:
         try:
             my_ip = requests.get("http://ifconfig.me").text
@@ -76,20 +142,8 @@ def store_head_requests(connection):
     latencies = []
     times = []
 
-    for hostname in hostnames:
-        times.append(datetime.datetime.now())
-        try:
-            response = requests.head(f"http://{hostname}")
-            latencies.append(response.elapsed.total_seconds())
-        except Exception:
-            latencies.append(None)
-
-    print(latencies)
-    records = []
-    for hostname, latency, times in zip(hostnames, latencies, times):
-        records.append(
-            (datetime.datetime.now(), int(latency*1000000), hostname, 1, location_key),
-        )
+    records = measure_latencies(measure_head_request, hostnames, [1, location_key])
+    records += measure_latencies(measure_ping_request, hostnames, [0, location_key])
 
     with connection.cursor() as cursor:
         cursor.executemany("""
@@ -105,7 +159,7 @@ def store_head_requests(connection):
         """, records
         )
     connection.commit()
-    print(f"saved {len(hostnames)} head requests infos")
+    logging.info(f"saved {len(records)} ping measurements")
 
 '''
 valid_servers = []
@@ -123,11 +177,14 @@ with open("servers.json", "w") as f:
 exit(0)
 '''
 if __name__ == "__main__":
+    logging.info("Starting up")
     prev_end_time = time.time()
     with get_connection(user="ping_inserter", password="665404ebeb06") as connection:
         while True:
-            store_head_requests(connection)
+            store_ping_and_head_latencies(connection)
             end_time = time.time()
             elapsed = end_time - prev_end_time
             prev_end_time = end_time
-            time.sleep(max(0, 60 - elapsed))
+            sleep_time = max(0, 60 - elapsed)
+            logging.info(f"Waiting {sleep_time:.2f} seconds until next round of pings...")
+            time.sleep(sleep_time)


### PR DESCRIPTION
The main upshot of this is there's now double the requests (ping_type 1 for HTTP header requests and 0 for ICMP ping), and pings should run more frequently, so it can actually manage to ping all servers within a minute (I spawned off up to 4 parallel threads). Let me know if anything in the data looks off